### PR TITLE
Refactory DataReader.IsDBNull method to avoid redundant bin packing

### DIFF
--- a/src/Pomelo.Data.MySql/datareader.cs
+++ b/src/Pomelo.Data.MySql/datareader.cs
@@ -808,7 +808,13 @@ namespace Pomelo.Data.MySql
         /// <returns></returns>
         public override bool IsDBNull(int i)
         {
-            return DBNull.Value == GetValue(i);
+            if (!isOpen)
+                Throw(new Exception("No current query in data reader"));
+            if (i >= FieldCount)
+                Throw(new IndexOutOfRangeException());
+
+            IMySqlValue val = GetFieldValue(i, false);
+            return val.IsNull;//原来调用 GetValue(int i)，如果是值类型，并且有值的话，会引起装箱。
         }
 
         /// <summary>


### PR DESCRIPTION
DataReader.IsDBNull will cause redundant bin packing issue. To invoke GetValue(int i), if the argument is  value type and with value will cause redundant bin packing.